### PR TITLE
fix: support GCC 14+ build compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc: [default, 14]
     steps:
       - uses: actions/checkout@v4
 
@@ -18,6 +21,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-multilib
 
+      - name: Install GCC ${{ matrix.gcc }}
+        if: matrix.gcc != 'default'
+        run: |
+          sudo apt-get install -y gcc-${{ matrix.gcc }} gcc-${{ matrix.gcc }}-multilib
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.gcc }} 100
+
+      - name: Show GCC version
+        run: gcc --version
+
       - name: Build c2asm370
         run: make
 
@@ -25,6 +37,7 @@ jobs:
         run: ./tests/run_tests.sh
 
       - name: Upload binary
+        if: matrix.gcc == 'default'
         uses: actions/upload-artifact@v4
         with:
           name: c2asm370-linux-x86

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ else
 endif
 
 DEFINES = -DIN_GCC -DHAVE_CONFIG_H -DPUREISO -DTARGET_MVS $(HOST_DEFINE) -DMVSGCC_CROSS
-CFLAGS = -std=c99 -fno-stack-protector -fno-builtin -fexceptions $(ARCH_FLAGS) -O1 $(EXTRA_CFLAGS) $(INCLUDES) $(DEFINES)
+CFLAGS = -std=gnu99 -Wno-error=implicit-function-declaration -Wno-error=int-conversion -Wno-error=incompatible-pointer-types -fno-stack-protector -fno-builtin -fexceptions $(ARCH_FLAGS) -O1 $(EXTRA_CFLAGS) $(INCLUDES) $(DEFINES)
 
 # sources for I370 (370 assembler source creation)
 I370_SRCS= \

--- a/gcc/config.h
+++ b/gcc/config.h
@@ -302,11 +302,7 @@ typedef union tree_node *tree;
 #undef HAVE_STRDUP
 
 /* Define if you have the strsignal function.  */
-#if defined(HOST_MACOS)
 #define HAVE_STRSIGNAL 1
-#else
-#undef HAVE_STRSIGNAL
-#endif
 
 /* Define if you have the strtoul function.  */
 #define HAVE_STRTOUL 1


### PR DESCRIPTION
## Summary
- Change `-std=c99` to `-std=gnu99` so POSIX functions (`realpath`, `asprintf`, `vasprintf`) remain visible without `__STRICT_ANSI__`
- Add `-Wno-error=` flags for the three warnings GCC 14 promoted to errors
- Extend CI matrix to also build with GCC 14

## Test plan
- [x] CI passes with default GCC (existing)
- [x] CI passes with GCC 14 (new matrix entry)
- [x] CI passes with clang on MacOS (existing)

Closes #1