### PR TITLE
Add Linux ARM64 (aarch64) build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,26 @@ jobs:
           name: c2asm370-linux-x86
           path: c2asm370
 
+  build-linux-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show GCC version
+        run: gcc --version
+
+      - name: Build c2asm370
+        run: make
+
+      - name: Run tests
+        run: ./tests/run_tests.sh
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: c2asm370-linux-arm64
+          path: c2asm370
+
   build-macos:
     runs-on: macos-14
     steps:
@@ -62,18 +82,24 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build-linux, build-macos]
+    needs: [build-linux, build-linux-arm64, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download Linux binary
+      - name: Download Linux x86 binary
         uses: actions/download-artifact@v4
         with:
           name: c2asm370-linux-x86
           path: release/linux
+
+      - name: Download Linux arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: c2asm370-linux-arm64
+          path: release/linux-arm64
 
       - name: Download macOS binary
         uses: actions/download-artifact@v4
@@ -84,8 +110,10 @@ jobs:
       - name: Prepare release assets
         run: |
           chmod +x release/linux/c2asm370
+          chmod +x release/linux-arm64/c2asm370
           chmod +x release/macos/c2asm370
           cd release/linux && tar czf ../../c2asm370-linux-x86.tar.gz c2asm370 && cd ../..
+          cd release/linux-arm64 && tar czf ../../c2asm370-linux-arm64.tar.gz c2asm370 && cd ../..
           cd release/macos && tar czf ../../c2asm370-macos-arm64.tar.gz c2asm370 && cd ../..
 
       - name: Create GitHub Release
@@ -94,4 +122,5 @@ jobs:
           generate_release_notes: true
           files: |
             c2asm370-linux-x86.tar.gz
+            c2asm370-linux-arm64.tar.gz
             c2asm370-macos-arm64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,18 @@ ifeq ($(UNAME_S),Darwin)
   LINK_ARCH_FLAGS =
   LINK_LIBS =
   EXTRA_CFLAGS = -fcommon -fgnu89-inline
+else ifneq (,$(filter aarch64 arm64,$(UNAME_M)))
+  # Linux on ARM64 — native 64-bit build.
+  # There is no usable 32-bit multilib on ARM64, so we do not use -m32.
+  # The 64-bit host configuration is selected automatically via __LP64__
+  # in gcc/config.h and gcc/auto-host.h (same path as the macOS build).
+  HOST_DEFINE = -DHOST_LINUX
+  ARCH_FLAGS =
+  LINK_ARCH_FLAGS =
+  LINK_LIBS = -lgcc
+  EXTRA_CFLAGS =
 else
-  # Linux (default, 32-bit build)
+  # Linux on x86 (default, 32-bit build)
   HOST_DEFINE = -DHOST_LINUX
   ARCH_FLAGS = -m32 -fno-pie
   LINK_ARCH_FLAGS = -m32 -no-pie

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c2asm370
 
-A C cross-compiler that produces IBM System/370 assembler source from C code. Built on a stripped-down GCC 3.2.3, it runs on Linux (32-bit) and macOS (including Apple Silicon) and generates mainframe-ready assembler output.
+A C cross-compiler that produces IBM System/370 assembler source from C code. Built on a stripped-down GCC 3.2.3, it runs on Linux (x86 32-bit and ARM64) and macOS (including Apple Silicon) and generates mainframe-ready assembler output.
 
 ## Background
 
@@ -21,7 +21,8 @@ The generated output uses:
 
 ### Requirements
 
-- **Linux:** GCC with 32-bit support (`gcc-multilib`)
+- **Linux (x86):** GCC with 32-bit support (`gcc-multilib`)
+- **Linux (ARM64):** GCC (native 64-bit build, no multilib needed)
 - **macOS:** Xcode Command Line Tools (Apple Silicon and Intel supported)
 - GNU Make
 

--- a/gcc/config.h
+++ b/gcc/config.h
@@ -541,7 +541,14 @@ typedef union tree_node *tree;
 #define HAVE_DECL_ATOL 1
 
 /* Define to 1 if we found this declaration otherwise define to 0. */
+/* On 64-bit (LP64) hosts the system header declares sbrk() as taking an
+   intptr_t (long), which conflicts with the fallback prototype in system.h
+   that uses int.  Use the system declaration there. */
+#if defined(__LP64__)
+#define HAVE_DECL_SBRK 1
+#else
 #define HAVE_DECL_SBRK 0
+#endif
 
 /* Define to 1 if we found this declaration otherwise define to 0. */
 #define HAVE_DECL_ABORT 1

--- a/i370/version.c
+++ b/i370/version.c
@@ -1,4 +1,4 @@
 #include "ansidecl.h"
 #include "version.h"
 
-const char *const version_string = "3.2.3 - c2asm370 version 1.2";
+const char *const version_string = "3.2.3 - c2asm370 version 1.3";


### PR DESCRIPTION
## Summary

Adds full Linux/ARM64 (aarch64) support, on par with the existing Linux/x86 and macOS/arm64 targets — build, CI, and release artifact.

## Background

The Linux build was hard-wired to `-m32` (32-bit). There is no usable 32-bit multilib on ARM64, so Linux/ARM64 must build natively as a 64-bit executable. Doing so surfaced a latent declaration conflict that neither Linux/x86 (32-bit) nor macOS triggers:

- On LP64 hosts glibc declares `sbrk()` as `sbrk(intptr_t)` (i.e. `long`).
- `system.h` provided a fallback prototype `sbrk(int)` whenever `HAVE_DECL_SBRK == 0`.
- On 32-bit `int == intptr_t`, and macOS declares `sbrk(int)`, so the clash only appears on 64-bit glibc.

## Changes

- **Makefile** — detect `aarch64`/`arm64` on Linux and build natively (no `-m32`/`-fno-pie`). Linux/x86 path is unchanged. The 64-bit host configuration is selected automatically via `__LP64__`, the same path already used by the macOS build.
- **gcc/config.h** — set `HAVE_DECL_SBRK 1` on `__LP64__` hosts so the system declaration is used instead of the conflicting `int`-based fallback.
- **.github/workflows/build.yml** — new `build-linux-arm64` job on `ubuntu-24.04-arm`; publish `c2asm370-linux-arm64` as a release artifact alongside x86 and macOS.
- **README.md** — document the new target.

## Validation

Built and tested in a real `aarch64` Ubuntu 24.04 container (matching the GitHub runner):

| Platform | Build | Tests |
|----------|-------|-------|
| linux/arm64 (new) | pass | 6/6 |
| macOS/arm64 (regression check after config.h edit) | pass | 6/6 |
| linux/x86 | logically unaffected (changes are gated), confirmed by CI | — |

The test suite compares generated HLASM against golden files, so the ARM64 build produces byte-identical assembler output to the other platforms.