### PR TITLE
Build native Linux x86-64 (amd64), drop 32-bit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install 32-bit build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-multilib
-
       - name: Install GCC ${{ matrix.gcc }}
         if: matrix.gcc != 'default'
         run: |
-          sudo apt-get install -y gcc-${{ matrix.gcc }} gcc-${{ matrix.gcc }}-multilib
+          sudo apt-get update
+          sudo apt-get install -y gcc-${{ matrix.gcc }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.gcc }} 100
 
       - name: Show GCC version
@@ -40,7 +36,7 @@ jobs:
         if: matrix.gcc == 'default'
         uses: actions/upload-artifact@v4
         with:
-          name: c2asm370-linux-x86
+          name: c2asm370-linux-amd64
           path: c2asm370
 
   build-linux-arm64:
@@ -89,10 +85,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download Linux x86 binary
+      - name: Download Linux amd64 binary
         uses: actions/download-artifact@v4
         with:
-          name: c2asm370-linux-x86
+          name: c2asm370-linux-amd64
           path: release/linux
 
       - name: Download Linux arm64 binary
@@ -112,7 +108,7 @@ jobs:
           chmod +x release/linux/c2asm370
           chmod +x release/linux-arm64/c2asm370
           chmod +x release/macos/c2asm370
-          cd release/linux && tar czf ../../c2asm370-linux-x86.tar.gz c2asm370 && cd ../..
+          cd release/linux && tar czf ../../c2asm370-linux-amd64.tar.gz c2asm370 && cd ../..
           cd release/linux-arm64 && tar czf ../../c2asm370-linux-arm64.tar.gz c2asm370 && cd ../..
           cd release/macos && tar czf ../../c2asm370-macos-arm64.tar.gz c2asm370 && cd ../..
 
@@ -121,6 +117,6 @@ jobs:
         with:
           generate_release_notes: true
           files: |
-            c2asm370-linux-x86.tar.gz
+            c2asm370-linux-amd64.tar.gz
             c2asm370-linux-arm64.tar.gz
             c2asm370-macos-arm64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # 2023-12-29: This Makefile creates the "c2asm370" executable on and for Linux.
-#             The resulting "c2asm370" is a 32 bit executable program that *should*
-#             run on 32 or 64 bit Linux machines.
+#             The resulting "c2asm370" is a native 64-bit executable
+#             (x86-64 / aarch64). macOS (Apple Silicon) is also supported.
 #
 #             When executing "c2asm370" you must use the '-S' option to create an
 #             assembler source file: ./c2asm370 -I pdpclib -S test.c
@@ -26,7 +26,6 @@ CC = gcc
 
 # Platform detection
 UNAME_S := $(shell uname -s)
-UNAME_M := $(shell uname -m)
 
 ifeq ($(UNAME_S),Darwin)
   # macOS (Apple Silicon or Intel)
@@ -35,21 +34,13 @@ ifeq ($(UNAME_S),Darwin)
   LINK_ARCH_FLAGS =
   LINK_LIBS =
   EXTRA_CFLAGS = -fcommon -fgnu89-inline
-else ifneq (,$(filter aarch64 arm64,$(UNAME_M)))
-  # Linux on ARM64 — native 64-bit build.
-  # There is no usable 32-bit multilib on ARM64, so we do not use -m32.
+else
+  # Linux — native 64-bit build (x86-64 / aarch64).
   # The 64-bit host configuration is selected automatically via __LP64__
   # in gcc/config.h and gcc/auto-host.h (same path as the macOS build).
   HOST_DEFINE = -DHOST_LINUX
   ARCH_FLAGS =
   LINK_ARCH_FLAGS =
-  LINK_LIBS = -lgcc
-  EXTRA_CFLAGS =
-else
-  # Linux on x86 (default, 32-bit build)
-  HOST_DEFINE = -DHOST_LINUX
-  ARCH_FLAGS = -m32 -fno-pie
-  LINK_ARCH_FLAGS = -m32 -no-pie
   LINK_LIBS = -lgcc
   EXTRA_CFLAGS =
 endif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c2asm370
 
-A C cross-compiler that produces IBM System/370 assembler source from C code. Built on a stripped-down GCC 3.2.3, it runs on Linux (x86 32-bit and ARM64) and macOS (including Apple Silicon) and generates mainframe-ready assembler output.
+A C cross-compiler that produces IBM System/370 assembler source from C code. Built on a stripped-down GCC 3.2.3, it runs as a native 64-bit binary on Linux (x86-64 and ARM64) and macOS (Apple Silicon) and generates mainframe-ready assembler output.
 
 ## Background
 
@@ -21,8 +21,7 @@ The generated output uses:
 
 ### Requirements
 
-- **Linux (x86):** GCC with 32-bit support (`gcc-multilib`)
-- **Linux (ARM64):** GCC (native 64-bit build, no multilib needed)
+- **Linux (x86-64 / ARM64):** GCC (native 64-bit build, no multilib needed)
 - **macOS:** Xcode Command Line Tools (Apple Silicon and Intel supported)
 - GNU Make
 

--- a/i370/version.c
+++ b/i370/version.c
@@ -1,4 +1,4 @@
 #include "ansidecl.h"
 #include "version.h"
 
-const char *const version_string = "3.2.3 - c2asm370 version 1.3";
+const char *const version_string = "3.2.3 - c2asm370 version 1.4";


### PR DESCRIPTION
Closes #5.

## Summary

Drops the Linux x86 **32-bit (ILP32)** build in favour of a native **x86-64 (LP64)** binary, removing the `gcc-multilib` dependency so the compiler builds on a modern stock toolchain.

After #4, macOS/arm64 and Linux/arm64 already build natively as 64-bit. This unifies the last remaining target on the same proven LP64 code path.

## Changes

- **Makefile:** drop `-m32 -fno-pie` / `-m32 -no-pie` from the Linux branch. Both Linux arches (x86-64, aarch64) are now native 64-bit, so the separate ARM64 branch from #4 merges back into a single Linux branch (Darwin + Linux). `UNAME_M` is no longer needed.
- **.github/workflows/build.yml:** remove the `gcc-multilib` install; keep the `gcc: [default, 14]` host matrix; rename the artifact and release asset `c2asm370-linux-x86` → **`c2asm370-linux-amd64`** (consistent with `c2asm370-linux-arm64`).
- **README.md:** platform/requirements updated.
- **i370/version.c:** 1.3 → 1.4.

No codegen changes — `__LP64__` already drives 64-bit sizing (incl. the `HAVE_DECL_SBRK` fix from #4).

## Validation

- Native x86-64 build (no multilib) in an `amd64` Ubuntu 24.04 container: builds clean, `run_tests.sh` 6/6.
- macOS/arm64 native build: builds clean, 6/6.
- **Output parity (preliminary):** the installed 32-bit reference vs a native 64-bit build produce **byte-identical** generated code across ufsd/rexx370/httpd (0/48 files differ; only the `-fverbose-asm` version-stamp comment differs). See [#5 comment](https://github.com/mvslovers/c2asm370/issues/5#issuecomment-4634384742).

## Acceptance gate before merge

Full-coverage `.s` parity check (32-bit reference vs amd64) on the three reference projects — owner to generate the `.s` sets, diff to confirm byte-identical (modulo the version-stamp comment).